### PR TITLE
第9章 発展的なログイン機構

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -177,3 +177,17 @@ input{
     color: $state-danger-text;
   }
 }
+
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
       if user && user.authenticate(params[:session][:password])
         #ユーザログイン後にユーザ情報にリダイレクトする。
         log_in user
-        params[:session][:remember] == '1' ? remember(user) : forget(user)
+        params[:session][:remember_me] == '1' ? remember(user) : forget(user)
         redirect_to user
       else
         flash.now[:danger] = "Invalid email/password combination"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
       if user && user.authenticate(params[:session][:password])
         #ユーザログイン後にユーザ情報にリダイレクトする。
         log_in user
+        remember user
         redirect_to user
       else
         flash.now[:danger] = "Invalid email/password combination"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
       if user && user.authenticate(params[:session][:password])
         #ユーザログイン後にユーザ情報にリダイレクトする。
         log_in user
-        remember user
+        params[:session][:remember] == '1' ? remember(user) : forget(user)
         redirect_to user
       else
         flash.now[:danger] = "Invalid email/password combination"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,8 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    #logged_in?がされている場合のみlog_outする。
+    log_out if logged_in?
     redirect_to root_url
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -11,15 +11,24 @@ module SessionsHelper
     cookies.permanent[:remember_token] = user.remember_token
   end
 
-  #ユーザーを永続的セッションに記憶する
+    # 記憶トークンcookieに対応するユーザーを返す
+    def current_user
+       #現在ログイン中のユーザを返す(いる場合)
+      if (user_id = session[:user_id])
+        @current_user ||= User.find_by(id: user_id)
+      elsif (user_id = cookies.signed[:user_id])
+        user = User.find_by(id: user_id)
+        if user && user.authenticated?(cookies[:remember_token])
+          log_in user
+          @current_user = user
+        end
+      end
+    end
+
+  #現在のユーザでログアウトする。
   def log_out
     session.delete(:user_id)
     @current_user = nil
-  end
-
-  #現在ログイン中のユーザを返す(いる場合)
-  def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
   end
 
   #ユーザがログインしていればtrue、その他ならfalseを返す。

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -25,8 +25,16 @@ module SessionsHelper
       end
     end
 
+  #永続的セッションを破棄する。
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   #現在のユーザでログアウトする。
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -11,19 +11,19 @@ module SessionsHelper
     cookies.permanent[:remember_token] = user.remember_token
   end
 
-    # 記憶トークンcookieに対応するユーザーを返す
-    def current_user
-       #現在ログイン中のユーザを返す(いる場合)
-      if (user_id = session[:user_id])
-        @current_user ||= User.find_by(id: user_id)
-      elsif (user_id = cookies.signed[:user_id])
-        user = User.find_by(id: user_id)
-        if user && user.authenticated?(cookies[:remember_token])
-          log_in user
-          @current_user = user
-        end
+  # 記憶トークンcookieに対応するユーザーを返す
+  def current_user
+     #現在ログイン中のユーザを返す(いる場合)
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
       end
     end
+  end
 
   #永続的セッションを破棄する。
   def forget(user)

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -4,7 +4,14 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
-  #現在のユーザでログアウトする。
+  #ユーザを永続的にセッションに記憶する。
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  #ユーザーを永続的セッションに記憶する
   def log_out
     session.delete(:user_id)
     @current_user = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   before_save{email.downcase!}
+  attr_accessor :remember_token
 
   validates :name, presence: true
   validates :email, presence: true
@@ -17,6 +18,18 @@ class User < ApplicationRecord
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST:
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string,cost: cost)
+  end
 
+  #ランダムなトークンを渡す。
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  #永続セッションのためにユーザーをデータベースに記憶する。
+  def remember
+    #記憶トークンを作成
+    self.remember_token = User.new_token
+    #記憶ダイジェストを更新
+    update_attribute(:remember_digest, User.digest(remember_token))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,4 +37,8 @@ class User < ApplicationRecord
   def authenticated?(remember_token)
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
+
+  def forget
+    update_attribute(:remember_digest,nil)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,9 @@ class User < ApplicationRecord
     #記憶ダイジェストを更新
     update_attribute(:remember_digest, User.digest(remember_token))
   end
+
+  #渡されたトークンがダイジェストとい一致したらtrueを返す。
+  def authenticated?(remember_token)
+    BCrypy::Password.new(remember_digest).is_password?(remember_token)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,6 @@ class User < ApplicationRecord
 
   #渡されたトークンがダイジェストとい一致したらtrueを返す。
   def authenticated?(remember_token)
-    BCrypy::Password.new(remember_digest).is_password?(remember_token)
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,13 +33,12 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, User.digest(remember_token))
   end
 
-  #渡されたトークンがダイジェストとい一致したらtrueを返す。
   def authenticated?(remember_token)
     return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 
   def forget
-    update_attribute(:remember_digest,nil)
+    update_attribute(:remember_digest, nil)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
 
   #渡されたトークンがダイジェストとい一致したらtrueを返す。
   def authenticated?(remember_token)
+    return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,6 +11,11 @@
       <%= f.label :password %>
       <%= f.password_field :password, class: 'form-control' %>
 
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+      <%= f.check_box :remember_me %>
+      <span>Remember me on this computer</span>
+      <% end %>
+
       <%= f.submit "Log in", class: "btn btn-primary" %>
     <% end %>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -13,7 +13,7 @@
 
       <%= f.label :remember_me, class: "checkbox inline" do %>
       <%= f.check_box :remember_me %>
-      <span>Remember me on this computer</span>
+        <span>Remember me on this computer</span>
       <% end %>
 
       <%= f.submit "Log in", class: "btn btn-primary" %>

--- a/db/migrate/20170706084937_add_remember_digest_to_users.rb
+++ b/db/migrate/20170706084937_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170629074346) do
+ActiveRecord::Schema.define(version: 20170706084937) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20170629074346) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+  def setup
+    @user = users(:michael)
+    remember(@user)
+  end
+
+  test 'current_user returns right user when session is nil' do
+    assert_equal @user, current_user
+    assert is_logged_in?
+  end
+
+  test 'current_user returns nil when remembe digest is wrong' do
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+    assert_nil current_user
+  end
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -7,7 +7,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   end
 
   #flashメッセージが消えたかを確認するテスト
-  test "login with invalid information" do
+  test 'login with invalid information' do
     get login_path
     assert_template 'sessions/new'
     post login_path, params: { session: { email: "", password: "" } }
@@ -38,4 +38,19 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+
+  test 'login with remembering' do
+    log_in_as(@user, remember_me:'1')
+    assert_not_empty cookies['remember_token']
+  end
+
+  test "login without remembering" do
+    # クッキーを保存してログイン
+    log_in_as(@user, remember_me: '1')
+    delete logout_path
+    # クッキーを削除してログイン
+    log_in_as(@user, remember_me: '0')
+    assert_empty cookies['remember_token']
+  end
+
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -18,7 +18,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   end
 
   #fixtureのデータを使ったユーザログイン/ログアウトのテスト
-  test 'login with valid information' do
+  test 'login with valid information followed by logout' do
     get login_path
     post login_path, params: { session: { email:    @user.email,
                                           password: 'password' } }
@@ -31,6 +31,8 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
     assert_not is_logged_in?
     assert_redirected_to root_url
+    #2番目のウィンドウでログアウトをクリックするユーザをシミュレートする。
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path,      count: 0

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -44,7 +44,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_not_empty cookies['remember_token']
   end
 
-  test "login without remembering" do
+  test 'login without remembering' do
     # クッキーを保存してログイン
     log_in_as(@user, remember_me: '1')
     delete logout_path

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -40,7 +40,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   end
 
   test 'login with remembering' do
-    log_in_as(@user, remember_me:'1')
+    log_in_as(@user, remember_me: '1')
     assert_not_empty cookies['remember_token']
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -79,4 +79,8 @@ class UserTest < ActiveSupport::TestCase
    assert_not @user.valid?
   end
 
+  #authenticated?にnilが来た場合の拒否テスト
+  test "authenticated? should return false for a user with nil digest" do
+    assert_not @user.authenticated?('')
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,8 +20,8 @@ class ActiveSupport::TestCase
   class ActionDispatch::IntegrationTest
     def log_in_as(user, password: 'password', remember_me: '1')
     post login_path, params: { session: { email: user.email,
-                                         password: password,
-                                         remember_me: remember_me } }
+                                          password: password,
+                                          remember_me: remember_me } }
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,4 +11,17 @@ class ActiveSupport::TestCase
   def is_logged_in?
     !session[:user_id].nil?
   end
+
+  #テストユーザとしてログインする。
+  def log_in_as(user)
+    session[:user_id] = user.id
+  end
+
+  class ActionDispatch::IntegrationTest
+    def log_in_as(user, password: 'password', remember_me: '1')
+    post login_path, params: { session: { email: user.email,
+                                         password: password,
+                                         remember_me: remember_me } }
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 
Ruby on Railsチュートリアルの第9章の発展的なログインを一通りやった。

## やった事

-  [Remember me]機能の実装。
- ログアウトの実装。
- ２つの目立たないバグの修正
  - ユーザーが1つのタブでログアウトし、もう1つのタブで再度ログアウトしようとするとエラーになる。
  - Firefoxでログアウトしたときに、ユーザーのremember_digestが削除してしまっているにもかかわらず、Chromeでアプリケーションにアクセスしたとき`authenticated?`メソッドで`BCrypt::Password.new(nil)`となり、例外処理が発生してエラーが起きる。
-  [Remember me]のテスト

## レビュワー

しずちゃん

## レビューポイント

重点的にみてほしい所。

- `sesssions_helpr.rb`
- `sessions_controller.rb`
- セッションヘルパーのテスト(`sessions_helper_test.rb`)

その他

- コードに余計な空行、空文字がないか。

## issue

- #34 