### PR TITLE
[WIP]認証APIの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
+# Use jwt
+gem 'jwt'
+
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jwt (1.5.6)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -233,6 +234,7 @@ DEPENDENCIES
   guard (= 2.13.0)
   guard-minitest (= 2.4.4)
   jbuilder (~> 2.5)
+  jwt
   listen (>= 3.0.5, < 3.2)
   minitest-reporters (= 1.1.9)
   pg (= 0.18.4)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,13 @@
+class AuthController < ApplicationController
+
+  protect_from_forgery with: :null_session
+
+  def login_api
+    @user = User.find_by(email: params[:email].downcase)
+      if @user && @user.authenticate(params[:password])
+        render "authed"
+      else
+        render "unauthed"
+      end
+  end
+end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,3 +1,5 @@
+require 'jwt'
+
 class AuthController < ApplicationController
 
   protect_from_forgery with: :null_session
@@ -5,6 +7,11 @@ class AuthController < ApplicationController
   def login_api
     @user = User.find_by(email: params[:email].downcase)
       if @user && @user.authenticate(params[:password])
+        #jwt
+        issued_at = Time.now
+        token = JWT.encode({ id: @user.id, iat: issued_at.to_i },
+                Rails.application.secrets.secret_key_base, 'HS256')
+        
         render "authed"
       else
         render "unauthed"

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -1,0 +1,3 @@
+module AuthHelper
+  
+end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -1,3 +1,7 @@
 module AuthHelper
-  
+  def generate_token(user)
+    exptime = Time.now.to_i + Rails.application.secrets.api_token_exp
+    payload = {iss: "example.com", exp: exptime, user_id: user.id}
+    JWT.encode payload, Rails.application.secrets.api_secret_key, 'HS256'
+  end
 end

--- a/app/views/auth/authed.json.jbuilder
+++ b/app/views/auth/authed.json.jbuilder
@@ -1,0 +1,2 @@
+json.(@user, :id)
+json.message "Success!"

--- a/app/views/auth/unauthed.json.jbuilder
+++ b/app/views/auth/unauthed.json.jbuilder
@@ -1,0 +1,1 @@
+json.message "Faild!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
 
   #ユーザ情報を取得するだけのJSON API用のエンドポインを追加
   scope :api, format: 'json' do
+    #認証JSON API様ののエンドポイント(/api/auth)を作成する。
+    post '/auth', to: 'auth#login_api'
     resources :users
   end
 end

--- a/test/controllers/auth_controller_test.rb
+++ b/test/controllers/auth_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AuthControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

認証APIを作成します。
認証APIにPOSTで`name`と`email`を送った際にリクエストヘッダーにtokenが付与する様に実装します。

- [x] アプリからemail, passwordをAPIに送った際にuser_idが返ってくる。
- [ ] 正しい組み合わせなら、user_idを含んだJWTを返す
- [ ] 以降のリクエストヘッダにそのトークンを付与する

(例)
```
# 認証のためのトークンを得る

POST https://example.com/api/auth
Headers:
  Accept: "application/json"
Params:
  email: "example@railstutorial.org"
  password: "foobar"

---

{
  "user": {
    "id": 1
    "name": "Example User",
    "icon_url": "https://secure.gravatar.com/avatar/xxxxxxxxxxxxxxxxxxx",
  },
  "token": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
}
```

## 内容

- `auth_controller`でAPIからの認証処理を実装。


## レビュワー

- がっちゃん

## レビューポイント

- 
